### PR TITLE
Resolved permissions issue

### DIFF
--- a/.github/workflows/dev-terraform.yml
+++ b/.github/workflows/dev-terraform.yml
@@ -29,7 +29,6 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v0
         with:
-          token_format: 'access_token'
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 

--- a/.github/workflows/dev-terraform.yml
+++ b/.github/workflows/dev-terraform.yml
@@ -30,8 +30,8 @@ jobs:
         uses: google-github-actions/auth@v0
         with:
           token_format: 'access_token'
-          workload_identity_provider: 'projects/737737952874/locations/global/workloadIdentityPools/github-pool/providers/github-actions'
-          service_account: 'storage-admin@dtc-dataops-dev.iam.gserviceaccount.com'
+          workload_identity_provider: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+          service_account: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: 'Setup gcloud SDK'
         uses: google-github-actions/setup-gcloud@v0

--- a/.github/workflows/dev-terraform.yml
+++ b/.github/workflows/dev-terraform.yml
@@ -30,8 +30,8 @@ jobs:
         uses: google-github-actions/auth@v0
         with:
           token_format: 'access_token'
-          workload_identity_provider: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
-          service_account: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
       - name: 'Setup gcloud SDK'
         uses: google-github-actions/setup-gcloud@v0

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ENV=dev
-BUCKET_NAME=dtc-${ENV}-terraform-state
+BUCKET_NAME=${ENV}-dtc-terraform-state
 PROJECT_ID:=$$(gcloud config get-value project)
 
 configure-backend:

--- a/dev/backend.tf
+++ b/dev/backend.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "gcs" {
-    bucket = "dtc-dev-terraform-state"
+    bucket = "dev-dtc-terraform-state"
     prefix = ""
   }
 


### PR DESCRIPTION
Was unable to build buckets because cloud object storage admin does not have the permissions to create buckets. You must use `storage admin` role as well. 